### PR TITLE
Manage clickhouse-common-static package, drop old OSes

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -1,14 +1,18 @@
-# @summary 
-#   Private class for managing Clickhouse client package.
+# @summary Private class for managing Clickhouse client package.
 #
 # @api private
 #
 class clickhouse::client::install {
   if $clickhouse::client::manage_package {
-    package { 'clickhouse-client':
+    package { 'clickhouse-common-static':
       ensure          => $clickhouse::client::package_ensure,
       install_options => $clickhouse::client::package_install_options,
-      name            => $clickhouse::client::package_name,
+    }
+
+    package { $clickhouse::client::package_name:
+      ensure          => $clickhouse::client::package_ensure,
+      install_options => $clickhouse::client::package_install_options,
+      require         => Package['clickhouse-common-static'],
     }
   }
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,5 +1,4 @@
-# @summary 
-#   Private class for managing Clickhouse server package.
+# @summary Private class for managing Clickhouse server package.
 #
 # @api private
 #
@@ -8,6 +7,12 @@ class clickhouse::server::install {
     package { $clickhouse::server::package_name:
       ensure          => $clickhouse::server::package_ensure,
       install_options => $clickhouse::server::package_install_options,
+    }
+
+    if $clickhouse::server::manage_service {
+      Package<| title == $clickhouse::server::package_name |> {
+        notify => Service[$clickhouse::server::service_name],
+      }
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "deric-clickhouse",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Tomas Barton",
   "summary": "Installs, configures and manages Clickhouse server and client",
   "license": "Apache-2.0",
@@ -25,19 +25,20 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -45,16 +46,16 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.2.0",

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -6,35 +6,42 @@ describe 'clickhouse::client' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-    end
 
-    context 'with defaults' do
-      let(:facts) { os_facts }
+      context 'with defaults' do
+        it { is_expected.to contain_package('clickhouse-client') }
+        it { is_expected.to contain_class('clickhouse::repo') }
+      end
 
-      it { is_expected.to contain_package('clickhouse-client') }
-      it { is_expected.to contain_class('clickhouse::repo') }
-    end
+      context 'with manage_package set to true' do
+        let(:params) { { manage_package: true } }
 
-    context 'with manage_package set to true' do
-      let(:params) { { manage_package: true } }
-      let(:facts) { os_facts }
+        it { is_expected.to contain_package('clickhouse-client') }
+      end
 
-      it { is_expected.to contain_package('clickhouse-client') }
-    end
+      context 'with manage_package set to false' do
+        let(:params) { { manage_package: false } }
 
-    context 'with manage_package set to false' do
-      let(:params) { { manage_package: false } }
-      let(:facts) { os_facts }
+        it { is_expected.not_to contain_package('clickhouse-client') }
+      end
 
-      it { is_expected.not_to contain_package('clickhouse-client') }
-    end
+      context 'with specific version' do
+        let(:params) do
+          {
+            manage_package: true,
+            package_ensure: '24.8.2.3'
+          }
+        end
 
-    context 'with manage_repo set to false' do
-      let(:params) { { manage_repo: false } }
-      let(:facts) { os_facts }
+        it { is_expected.to contain_package('clickhouse-client').with(ensure: '24.8.2.3') }
+        it { is_expected.to contain_package('clickhouse-common-static').with(ensure: '24.8.2.3') }
+      end
 
-      it { is_expected.not_to contain_class('clickhouse::repo') }
-      it { is_expected.to contain_package('clickhouse-client') }
+      context 'with manage_repo set to false' do
+        let(:params) { { manage_repo: false } }
+
+        it { is_expected.not_to contain_class('clickhouse::repo') }
+        it { is_expected.to contain_package('clickhouse-client') }
+      end
     end
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -73,12 +73,23 @@ describe 'clickhouse::server' do
     context 'clickhouse::server::install' do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_package('clickhouse-server').with(ensure: 'present') }
+      it { is_expected.to contain_package('clickhouse-server').with(ensure: %r{^(present|installed)}) }
 
       context 'with manage_package set to true' do
         let(:params) { { manage_package: true } }
 
         it { is_expected.to contain_package('clickhouse-server') }
+      end
+
+      context 'with specific version' do
+        let(:params) do
+          {
+            manage_package: true,
+            package_ensure: '24.8.2.3'
+          }
+        end
+
+        it { is_expected.to contain_package('clickhouse-server').with(ensure: '24.8.2.3') }
       end
 
       context 'with manage_package set to false' do


### PR DESCRIPTION
- Manage `'clickhouse-common-static'` package
- Support upgrading to specific version